### PR TITLE
PadMu3 strings + pycryptodomex --> pycryptodome

### DIFF
--- a/DeBooxUpx.py
+++ b/DeBooxUpx.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-from Cryptodome.Cipher import AES
-from Cryptodome.Cipher import DES
-from Cryptodome.Hash import MD5
+from Crypto.Cipher import AES
+from Crypto.Cipher import DES
+from Crypto.Hash import MD5
 from base64 import b64decode
 
 boox_strings = {
+    'PadMu3': {
+        "MODEL": "PadMuAP3",
+        "STRING_SETTINGS": "TCP3lGFLuxm7wOXWnaomQAdYikpFPAOj5U2LK0Dck3Un",
+        "STRING_UPGRADE": "PC3wkRM4zhgstNIQLGR+dW9jourXdEXZXU/mN7bTACu0",
+        "STRING_LOCAL": "In/UoUFVkUdHTCqlSfCgKi8MEZGHK0Xc70Y5trXs"
+    },
     'NovaPro': {
         "MODEL": "NovaPro",
         "STRING_SETTINGS": "j857wYAQcWZgvIEQ/tcQqzxreUJgFHwJl6D2TN9BuSkQ",

--- a/DeBooxUpx.py
+++ b/DeBooxUpx.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python3
-from Crypto.Cipher import AES
-from Crypto.Cipher import DES
-from Crypto.Hash import MD5
+try:
+    from Cryptodome.Cipher import AES
+    from Cryptodome.Cipher import DES
+    from Cryptodome.Hash import MD5
+except ModuleNotFoundError:
+    from Crypto.Cipher import AES
+    from Crypto.Cipher import DES
+    from Crypto.Hash import MD5
+    from Crypto import version_info
+    if version_info[0] == 2:
+        raise SystemExit('Need either `pycryptodome` or `pycryptodomex`,'\
+                ' NOT `pycrypto`!')
 from base64 import b64decode
 
 boox_strings = {

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Any other issue and pull request is also welcomed!
 
 ## How to run?
 
-Python3 should be installed to run the script, and `pycryptodomex` a dependency of the script should also be installed:
+Python3 should be installed to run the script, and `pycryptodome` a dependency of the script should also be installed:
 
 (BTW: in some environments, the following `pip` and `python` should be replaced with `pip3` and `python3`)
 
 ```bash
-pip install pycryptodomex
+pip install pycryptodome
 ```
 
 You can run the application by putting `update.upx` file in the project directory and running
@@ -80,6 +80,7 @@ decrypter.deUpx(updateUpxPath, decryptedPath)
 |  Nova3   |  `Nova3`   |`VUkFew9KjsE54uQMSZI+S2tT1RRckT/vKkfiFFqImxi7`|`VEsMcHw88MpwOByhT7zqNhRFTQcruVMqhdllIlY6T+6f`|`TGlcNi8npJe4EHxzOKbCXakJKDssoRldHueY5OGl`|
 | NovaPlus | `NovaPlus` |`MtoBkApRAVwzdGe2CTnaE4MIgevRYNQfaKo606tyUQNY`|`Nttwkwxaei8xorBu/uUBpUu8nNZHTRIAZMZc0xrJs9Ti`|`LIYj1F9NVXFrOfi24/C76gFFxHYSCJ4mfhYI4q5w`|
 | NovaPro  | `NovaPro`  |`j857wYAQcWZgvIEQ/tcQqzxreUJgFHwJl6D2TN9BuSkQ`|`+soGw/YVdGIRJiAs5SMmv1ihW37H1Fa9+/1w2Vgt14Ag`|`lpsj9NJ8Kzv8jHb+OO8A5lxC+9Zhl243bFmDZYaF`|
+|  PadMu3  | `PadMuAP3` |`TCP3lGFLuxm7wOXWnaomQAdYikpFPAOj5U2LK0Dck3Un`|`PC3wkRM4zhgstNIQLGR+dW9jourXdEXZXU/mN7bTACu0`|`In/UoUFVkUdHTCqlSfCgKi8MEZGHK0Xc70Y5trXs`|
 |Poke2Color|`Poke2Color`|`I7ewiUSud0x9auT0PKp29393K5Hg3ymr1VJY5eUhoHEm`|`JLe4ijbRcj5L8S9cRPRGL7eoEIKjT8OOblhy/wyvSbze`|`SODgyWbHLhfjy4WWk6lhqhYXnP1FTjSjtzMTyZkl`|
 |  Poke3   |  `Poke3`   |`lU95mOkt0cGucrsrIdAWuYnoJEnTTfIvu/QNUlcmI42A`|`kjl4lOMqobWYQyqX4KzBGYS8Q0OwPSfqwf29ymkypULP`|`iW9b2bszjJhv3puv87HNQXLW3Fb5uQVhWnnKU4nV`|
 <!--(strings table end)-->


### PR DESCRIPTION
This PR contains two independent changes (bad practice, I know).

1. Add strings for PadMu3, a Max3 variant [primarily for musicians](https://www.padformusician.com/en/products) (although they seem to have moved on the the newer heavier Max Lumi with front lights)
2. Swap `cryptodomex` for `cryptodome` proper, as I don't suppose `pycrypto` is still a concern [please ignore those changes, if you think this is a problem)